### PR TITLE
Remove 'Return to Today' button/link

### DIFF
--- a/www/templates/default/html/js/events.js
+++ b/www/templates/default/html/js/events.js
@@ -188,15 +188,6 @@ require(['jquery', 'wdn', 'modernizr'], function($, WDN, Modernizr) {
 			addMonthWidgetStates();
 			stickySidebar();
 			
-			// Add a button for returning to "Today"
-			$('<p>')
-				.append($('<a>', {'class': 'return-today eventicon-angle-circled-left', 'href': '#'}).text('Return to today'))
-				.click(function(e) {
-					e.preventDefault();
-					changeDay(new Date());
-				})
-				.insertAfter($sidebarCal);
-			
 			$sidebarCal.on('click', 'td a', function(e) {
 				e.preventDefault();
 				changeDay(this.href);


### PR DESCRIPTION
There is concern for how much event content is visible at mobile widths. This link is redundant (there are 2 other ways to access today's events—the date on the calendar widget and the above 'Today' link) and it pushes content further down the screen.

I think in future sprints we should look at ways to incorporate this link's AJAX into other areas of Events.
