### PR TITLE
Format dates as ISO 8601

### DIFF
--- a/src/UNL/UCBCN/Frontend/EventInstance.php
+++ b/src/UNL/UCBCN/Frontend/EventInstance.php
@@ -249,10 +249,8 @@ class EventInstance implements RoutableInterface
         $data['EventTitle']    = $this->event->title;
         $data['EventSubtitle'] = $this->event->subtitle;
         $data['DateTime'] = array(
-            'StartDate' => date('Y-m-d', $startu),
-            'StartTime' => date('H:i:s', $startu),
-            'EndDate'   => date('Y-m-d', $endu),
-            'EndTime'   => date('H:i:s', $endu),
+            'Start' => date('c', $startu),
+            'End'   => date('c', $endu),
         );
         $data['EventStatus']           = 'Happening As Scheduled';
         $data['Classification']        = 'Public';


### PR DESCRIPTION
The date should be as interoperable as possible, and ISO 8601 is a widely accepted standard.
