### PR TITLE
Send CORS headers on xml requests

### DIFF
--- a/src/UNL/UCBCN/Frontend/OutputController.php
+++ b/src/UNL/UCBCN/Frontend/OutputController.php
@@ -41,6 +41,7 @@ class OutputController extends \Savvy
 
             case 'xml':
                 header('Content-type:text/xml');
+                $this->sendCORSHeaders();
                 $this->setTemplateFormatPaths($options['format']);
                 break;
 


### PR DESCRIPTION
It looks like the wdn templates month widget uses the XML output, and is being blocked due to CORS
