### PR TITLE
Make the trailing slash optional for some endpoints

### DIFF
--- a/data/routes.php
+++ b/data/routes.php
@@ -18,17 +18,17 @@ $week     = 'W(?P<w>[0-5][0-9])';
 // Used for determining an output format, e.g. .xml, .html
 $format   = '(\.(?P<format>[\w]+))?';
 
-$routes['/^images\/(?P<id>[\d]+)$/']                                                     = 'UNL\UCBCN\Frontend\Image';
-$routes['/^'.$calendar.'upcoming'.'\/'.$format.'$/']                                     = 'UNL\UCBCN\Frontend\Upcoming';
-$routes['/^'.$calendar.'week'.'\/'.$format.'$/']                                         = 'UNL\UCBCN\Frontend\Week';
-$routes['/^'.$calendar.'search'.'\/$/']                                                  = 'UNL\UCBCN\Frontend\Search';
-$routes['/^'.$calendar.'$/']                                                             = 'UNL\UCBCN\Frontend\Day';
-$routes['/^'.$calendar.$year.'\/'.$format.'$/']                                          = 'UNL\UCBCN\Frontend\Year';
-$routes['/^'.$calendar.$year.'\/'.$month.'\/'.$format.'$/']                              = 'UNL\UCBCN\Frontend\Month';
-$routes['/^'.$calendar.$year.'\/'.$month.'\/widget\/'.$format.'$/']                      = 'UNL\UCBCN\Frontend\MonthWidget';
-$routes['/^'.$calendar.$year.'\/'.$week.'\/'.$format.'$/']                               = 'UNL\UCBCN\Frontend\Week';
-$routes['/^'.$calendar.$year.'\/'.$month.'\/'.$day.'\/'.$format.'$/']                    = 'UNL\UCBCN\Frontend\Day';
-$routes['/^'.$calendar.$year.'\/'.$month.'\/'.$day.'\/(?P<id>[\d]+)'.'\/'.$format.'$/']  = 'UNL\UCBCN\Frontend\EventInstance';
+$routes['/^images\/(?P<id>[\d]+)$/']                                                        = 'UNL\UCBCN\Frontend\Image';
+$routes['/^'.$calendar.'upcoming'.'(\/)?'.$format.'$/']                                     = 'UNL\UCBCN\Frontend\Upcoming';
+$routes['/^'.$calendar.'week'.'(\/)?'.$format.'$/']                                         = 'UNL\UCBCN\Frontend\Week';
+$routes['/^'.$calendar.'search'.'\/$/']                                                     = 'UNL\UCBCN\Frontend\Search';
+$routes['/^'.$calendar.'$/']                                                                = 'UNL\UCBCN\Frontend\Day';
+$routes['/^'.$calendar.$year.'(\/)?'.$format.'$/']                                          = 'UNL\UCBCN\Frontend\Year';
+$routes['/^'.$calendar.$year.'\/'.$month.'(\/)?'.$format.'$/']                              = 'UNL\UCBCN\Frontend\Month';
+$routes['/^'.$calendar.$year.'\/'.$month.'\/widget(\/)?'.$format.'$/']                      = 'UNL\UCBCN\Frontend\MonthWidget';
+$routes['/^'.$calendar.$year.'\/'.$week.'(\/)?'.$format.'$/']                               = 'UNL\UCBCN\Frontend\Week';
+$routes['/^'.$calendar.$year.'\/'.$month.'\/'.$day.'(\/)?'.$format.'$/']                    = 'UNL\UCBCN\Frontend\Day';
+$routes['/^'.$calendar.$year.'\/'.$month.'\/'.$day.'\/(?P<id>[\d]+)'.'(\/)?'.$format.'$/']  = 'UNL\UCBCN\Frontend\EventInstance';
 
 
 return $routes;


### PR DESCRIPTION
Some older URLs make use of endpoints without the trailing slash.  A better approach might be to create redirects, but that would mean duplicating much of this regex, and the conical URLs for each endpoint are already being listed.
