### PR TITLE
Fix legacy calendar URLs defined by the `calendar_id`

### DIFF
--- a/src/UNL/UCBCN/Frontend/Controller.php
+++ b/src/UNL/UCBCN/Frontend/Controller.php
@@ -141,7 +141,7 @@ class Controller
             $this->options['calendar'] = Calendar::getByShortName($this->options['calendar_shortname']);
         } else if (!empty($this->options['calendar_id'])) {
             $this->options['calendar'] = Calendar::getByID($this->options['calendar_id']);
-        }else {
+        } else {
             $this->options['calendar'] = Calendar::getByID(self::$default_calendar_id);
         }
 

--- a/src/UNL/UCBCN/Frontend/Controller.php
+++ b/src/UNL/UCBCN/Frontend/Controller.php
@@ -139,7 +139,9 @@ class Controller
         if (!empty($this->options['calendar_shortname'])) {
             // Try and get by shortname
             $this->options['calendar'] = Calendar::getByShortName($this->options['calendar_shortname']);
-        } else {
+        } else if (!empty($this->options['calendar_id'])) {
+            $this->options['calendar'] = Calendar::getByID($this->options['calendar_id']);
+        }else {
             $this->options['calendar'] = Calendar::getByID(self::$default_calendar_id);
         }
 


### PR DESCRIPTION
Allow determining the current calendar by the presence of `calendar_id`
Fixes #127
