### PR TITLE
Fix json output for recurring dates

### DIFF
--- a/src/UNL/UCBCN/Frontend/EventInstance.php
+++ b/src/UNL/UCBCN/Frontend/EventInstance.php
@@ -235,8 +235,8 @@ class EventInstance implements RoutableInterface
     
     public function toJSONData()
     {
-        $startu     = strtotime($this->eventdatetime->starttime);
-        $endu       = strtotime($this->eventdatetime->endtime);
+        $startu     = strtotime($this->getStartTime());
+        $endu       = strtotime($this->getEndTime());
         $location   = $this->eventdatetime->getLocation();
         $eventTypes = $this->event->getEventTypes();
         $webcasts   = $this->event->getWebcasts();


### PR DESCRIPTION
The start date was always being shown, even if it was a recurring event on a different date.  Using the `getStartTime()` and `getEndTime()` methods accounts for the currently selected recurring date.
