### PR TITLE
Prevent malformed URLs when loading specific day content

### DIFF
--- a/www/templates/default/html/js/events.js
+++ b/www/templates/default/html/js/events.js
@@ -120,10 +120,23 @@ require(['jquery', 'wdn', 'modernizr'], function($, WDN, Modernizr) {
 			} else {
 				url = datetime;
 			}
-			
+
+			//Save the URL in history for the day before we append the hcal format
 			pushState(url, 'day');
+			
+			//Append the hcal format for ajax loading (partial content)
+			var format = 'format=hcalendar';
+			if (url.charAt(url.length - 1) === '?') {
+				url = url + format;
+			} else if (url.indexOf('?') > 0) {
+				url = url + '&' + format;
+			} else {
+				url = url + '?' + format;
+			}
+			
+			//Get the goods
 			scheduleProgress($loadTo);
-			$.get(url + '?format=hcalendar', function(data) {
+			$.get(url, function(data) {
 				cancelProgress();
 				$loadTo.html(data);
 				determineActiveDay();


### PR DESCRIPTION
For example, if someone visited `/calendar/?test` the code would have sent a request to load the day's content to `/calendar/?test?format=hcalendar`, and many browsers would thus return the full page content (ignoring the second `?`).
