### PR TITLE
Use the starting date of the first recurring date in an ongoing series

### DIFF
--- a/src/UNL/UCBCN/Frontend/EventInstance.php
+++ b/src/UNL/UCBCN/Frontend/EventInstance.php
@@ -187,7 +187,8 @@ class EventInstance implements RoutableInterface
         $time = $this->eventdatetime->starttime;
         
         if ($this->recurringdate) {
-            $time = $this->recurringdate->recurringdate . ' ' . substr($time, 11);
+            $first_recurring_date = $this->recurringdate->getFirstRecordInOngoingSeries();
+            $time = $first_recurring_date->recurringdate . ' ' . substr($time, 11);
         }
 
         return $time;


### PR DESCRIPTION
Please do not merge until after https://github.com/unl/UNL_UCBCN/pull/26 is merged and this PR is updated to include a bump to the backend submodule.

This PR should the starting dates of ongoing recurring events so that they show the actual start date and NOT the current date.
