### PR TITLE
Remove ucwords(strtolower( for location names

### DIFF
--- a/www/templates/default/html/EventInstance/FullLocation.tpl.php
+++ b/www/templates/default/html/EventInstance/FullLocation.tpl.php
@@ -6,9 +6,9 @@ $directions = isset($location->directions) ? $location->directions : $context->e
 <?php if (isset($location->name) || $room || $directions || isset($location->streetaddress1)): ?>
 <div class="location eventicon-location">
 <?php if (isset($location->mapurl)): ?>
-    <a class="mapurl" href="<?php echo $location->mapurl ?>"><?php echo ucwords(strtolower($location->name)) ?></a>
+    <a class="mapurl" href="<?php echo $location->mapurl ?>"><?php echo $location->name ?></a>
 <?php else: ?>
-    <?php echo ucwords(strtolower($location->name)) ?>
+    <?php echo $location->name ?>
 <?php endif; ?>
 <?php if ($room): ?>
     <span class="room">Room: <?php echo $room ?></span>

--- a/www/templates/default/html/EventInstance/Location.tpl.php
+++ b/www/templates/default/html/EventInstance/Location.tpl.php
@@ -3,9 +3,9 @@
 <?php if (isset($l->mapurl) || !empty($l->name)): ?>
     <span class="location eventicon-location">
 <?php if (isset($l->mapurl)): ?>
-        <a class="mapurl" href="<?php echo $l->mapurl ?>"><?php echo ucwords(strtolower($l->name)) ?></a>
+        <a class="mapurl" href="<?php echo $l->mapurl ?>"><?php echo $l->name ?></a>
 <?php else: ?>
-        <?php echo ucwords(strtolower($l->name)); ?>
+        <?php echo $l->name; ?>
 <?php endif; ?>
     </span>
 <?php endif; ?>


### PR DESCRIPTION
This functionality was causing acronyms (and other odd strings) in locations to display incorrectly on the frontend. I have gone into the live database and correctly formatted all location entries where standard = 1...we will leave non-standard entries as they are.
