### PR TITLE
Fix for upcoming view not respecting unlinked/deleted recurring events

### DIFF
--- a/src/UNL/UCBCN/Frontend/Upcoming.php
+++ b/src/UNL/UCBCN/Frontend/Upcoming.php
@@ -78,7 +78,7 @@ class Upcoming extends EventListing implements RoutableInterface
                 FROM eventdatetime as e
                 INNER JOIN event ON e.event_id = event.id
                 INNER JOIN calendar_has_event ON calendar_has_event.event_id = event.id
-                LEFT JOIN recurringdate ON (recurringdate.event_id = event.id)
+                LEFT JOIN recurringdate ON (recurringdate.event_id = event.id AND recurringdate.unlinked = 0)
                 WHERE
                     calendar_has_event.calendar_id = ' . (int)$this->calendar->id . '
                     AND (


### PR DESCRIPTION
Pretty self-explanatory...the Upcoming view on the frontend would show events that were deleted from a series of recurring events.
