### PR TITLE
Allow more shortnames in calendar routes

### DIFF
--- a/data/routes.php
+++ b/data/routes.php
@@ -7,7 +7,7 @@ $routes         = array();
 /* Commonly used regular expressions */
 
 // Optional calendar short name, which prefixes all routes
-$calendar                = '(?P<calendar_shortname>([a-zA-Z-_]([0-9]+)?)+)';
+$calendar                = '(?P<calendar_shortname>([a-zA-Z-_0-9]+)+)';
 $calendar_slash_required = '(' . $calendar . '\/)?';
 $calendar_slash_optional = '(' . $calendar . '(\/)?)?';
 

--- a/data/routes.php
+++ b/data/routes.php
@@ -7,7 +7,7 @@ $routes         = array();
 /* Commonly used regular expressions */
 
 // Optional calendar short name, which prefixes all routes
-$calendar                = '(?P<calendar_shortname>([a-zA-Z-_0-9]+)+)';
+$calendar                = '(?P<calendar_shortname>([a-zA-Z0-9-_]+)+)';
 $calendar_slash_required = '(' . $calendar . '\/)?';
 $calendar_slash_optional = '(' . $calendar . '(\/)?)?';
 


### PR DESCRIPTION
The current regex sitting here is restrictive, and does not allow for calendar shortnames that begin with a number, such as "4h". Since we don't currently enforce this pattern on creating a calendar shortname (and probably shouldn't) we shouldn't check it here.
